### PR TITLE
Synchronize access to @client_threads in LogStash::Outputs::Tcp

### DIFF
--- a/lib/logstash/outputs/tcp.rb
+++ b/lib/logstash/outputs/tcp.rb
@@ -75,23 +75,32 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
       @logger.info("Starting tcp output listener", :address => "#{@host}:#{@port}")
       @server_socket = TCPServer.new(@host, @port)
       @client_threads = []
+      @client_threads_lock = Mutex.new
 
       @accept_thread = Thread.new(@server_socket) do |server_socket|
         loop do
-          client_thread = Thread.start(server_socket.accept) do |client_socket|
-            client = Client.new(client_socket, @logger)
-            Thread.current[:client] = client
-            client.run
+          @client_threads_lock.synchronize do
+            @client_threads << Thread.start(server_socket.accept) do |client_socket|
+              begin
+                client = Client.new(client_socket, @logger)
+                Thread.current[:client] = client
+                client.run
+              ensure
+                @client_threads_lock.synchronize do
+                  @client_threads.delete(Thread.current)
+                end
+              end
+            end
           end
-          @client_threads << client_thread
         end
       end
 
       @codec.on_event do |payload|
-        @client_threads.each do |client_thread|
-          client_thread[:client].write(payload)
+        # dup @client_threads to avoid holding the lock while writing to clients
+        threads = @client_threads_lock.synchronize { @client_threads.dup }
+        threads.each do |thread|
+          thread[:client].write(payload)
         end
-        @client_threads.reject! {|t| !t.alive? }
       end
     else
       client_socket = nil


### PR DESCRIPTION
From original PR https://github.com/elasticsearch/logstash/pull/1270

---

Logstash was consistently failing with the following error when a client connected to a TCP output:

```
NoMethodError: undefined method `write' for nil:NilClass
       register at /opt/logstash/lib/logstash/outputs/tcp.rb:92
           each at org/jruby/RubyArray.java:1613
       register at /opt/logstash/lib/logstash/outputs/tcp.rb:91
           call at org/jruby/RubyProc.java:271
         encode at /opt/logstash/lib/logstash/codecs/json.rb:45
        receive at /opt/logstash/lib/logstash/outputs/tcp.rb:143
         handle at /opt/logstash/lib/logstash/outputs/base.rb:86
     initialize at (eval):21
           call at org/jruby/RubyProc.java:271
         output at /opt/logstash/lib/logstash/pipeline.rb:266
   outputworker at /opt/logstash/lib/logstash/pipeline.rb:225
  start_outputs at /opt/logstash/lib/logstash/pipeline.rb:152
```

Logstash at the time was receiving a heavy stream of events, so this is likely the result of a race condition accessing `@client_threads` which is not thread safe, so this change synchronizes access to it across threads.
