### PR TITLE
Remove deprecated config for 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.0
+## 3.1.0
   - breaking,config: Remove deprecated config `message_format`
 
 ## 3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
+## 4.0.0
+  - breaking,config: Remove deprecated config `message_format`
+
 ## 3.0.1
-  - Republish all the gems under jruby.
+ - Republish all the gems under jruby.
+
 ## 3.0.0
-  - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
-# 2.0.4
-  - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.3
-  - New dependency requirements for logstash-core for the 5.0 release
+ - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
+
+## 2.0.4
+ - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
+
+## 2.0.3
+ - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/outputs/tcp.rb
+++ b/lib/logstash/outputs/tcp.rb
@@ -22,21 +22,13 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
   # When mode is `server`, the port to listen on.
   # When mode is `client`, the port to connect to.
   config :port, :validate => :number, :required => true
-  
+
   # When connect failed,retry interval in sec.
   config :reconnect_interval, :validate => :number, :default => 10
 
   # Mode to operate in. `server` listens for client connections,
   # `client` connects to a server.
   config :mode, :validate => ["server", "client"], :default => "client"
-
-  # The format to use when writing events to the file. This value
-  # supports any string and can include `%{name}` and other dynamic
-  # strings.
-  #
-  # If this setting is omitted, the full json representation of the
-  # event will be written as a single line.
-  config :message_format, :validate => :string, :deprecated => true
 
   class Client
     public
@@ -132,14 +124,6 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
 
   public
   def receive(event)
-    
-
-    #if @message_format
-      #output = event.sprintf(@message_format) + "\n"
-    #else
-      #output = event.to_hash.to_json + "\n"
-    #end
-    
     @codec.encode(event)
   end # def receive
 end # class LogStash::Outputs::Tcp

--- a/logstash-output-tcp.gemspec
+++ b/logstash-output-tcp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-tcp'
-  s.version         = '4.0.0'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Write events over a TCP socket."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-tcp.gemspec
+++ b/logstash-output-tcp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-tcp'
-  s.version         = '3.0.1'
+  s.version         = '4.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Write events over a TCP socket."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Meta issue => https://github.com/elastic/logstash/issues/3858

Fun point is that this config is deactivated since https://github.com/logstash-plugins/logstash-output-tcp/commit/dccc5cba3667675f7dab2f12a3f3102d3e7e5ce8  **committed on Oct 20, 2014**