### PR TITLE
set concurrency to single

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 3.2.0
- - Added SSL support to this plugin (@michaelweiser)
+## 4.0.0
+ - Remove deprecated `workers_not_supported` call
+ - Use concurrency :single
 
 ## 3.1.1
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99

--- a/lib/logstash/outputs/tcp.rb
+++ b/lib/logstash/outputs/tcp.rb
@@ -13,6 +13,7 @@ require "logstash/util/socket_peer"
 class LogStash::Outputs::Tcp < LogStash::Outputs::Base
 
   config_name "tcp"
+  concurrency :single
 
   default :codec, "json"
 
@@ -115,8 +116,6 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
     end # @ssl_enable
 
     if server?
-      workers_not_supported
-
       @logger.info("Starting tcp output listener", :address => "#{@host}:#{@port}")
       begin
         @server_socket = TCPServer.new(@host, @port)

--- a/logstash-output-tcp.gemspec
+++ b/logstash-output-tcp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-tcp'
-  s.version         = '3.2.0'
+  s.version         = '4.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Write events over a TCP socket."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Part of the meta issue https://github.com/elastic/logstash/issues/5663

this PR updates the plugin output delegation strategy to conform with https://github.com/elastic/logstash/pull/5752

Using `concurrency :single` makes a single instance of the plugin to be shared accross all pipeline workers. However only 1 will be able to use the plugin at a time.

See https://github.com/logstash-plugins/logstash-output-tcp/pull/20 for a longer running rework to make the plugin be threadsafe, in order to set `concurrency :shared`.