### PR TITLE
Use sync socket write to ensure that full message is written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.0.1
+  - Use sync socket write to ensure that full message is written to socket.
+  
 ## 6.0.0
   - Removed obsolete field `message_format`
 

--- a/lib/logstash/outputs/tcp.rb
+++ b/lib/logstash/outputs/tcp.rb
@@ -151,14 +151,7 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
       @codec.on_event do |event, payload|
         begin
           client_socket = connect unless client_socket
-          r,w,e = IO.select([client_socket], [client_socket], [client_socket], nil)
-          # don't expect any reads, but a readable socket might
-          # mean the remote end closed, so read it and throw it away.
-          # we'll get an EOFError if it happens.
-          client_socket.sysread(16384) if r.any?
-
-          # Now send the payload
-          client_socket.syswrite(payload) if w.any?
+          client_socket.syswrite(payload)
         rescue => e
           @logger.warn("tcp output exception", :host => @host, :port => @port,
                        :exception => e, :backtrace => e.backtrace)

--- a/logstash-output-tcp.gemspec
+++ b/logstash-output-tcp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-tcp'
-  s.version         = '6.0.0'
+  s.version         = '6.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events over a TCP socket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This replaces the select call on the socket with a simple sync write since the async write call was not properly verifying that the entire payload was written to the socket and there wasn't really a performance benefit with the existing async write. The failure to verify that the entire payload was written to the socket is the suspected cause of truncated messages in situations where unusually long messages were sent via TCP.

May relate to #30 and #33.
