### PR TITLE
Ensuring that an entire message has been sent by calling SSLSocket/TCPSocket.syswrite in loop

### DIFF
--- a/lib/logstash/outputs/tcp.rb
+++ b/lib/logstash/outputs/tcp.rb
@@ -158,7 +158,12 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
           client_socket.sysread(16384) if r.any?
 
           # Now send the payload
-          client_socket.syswrite(payload) if w.any?
+          if w.any?
+            while payload.bytesize > 0
+              written = client_socket.syswrite(payload)
+              payload = payload.byteslice(written..-1)
+            end
+          end
         rescue => e
           @logger.warn("tcp output exception", :host => @host, :port => @port,
                        :exception => e, :backtrace => e.backtrace)

--- a/logstash-output-tcp.gemspec
+++ b/logstash-output-tcp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-tcp'
-  s.version         = '6.0.0'
+  s.version         = '6.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events over a TCP socket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes #30 #33 where messages longer than jruby-openssl OpenSSL::Buffering::BLOCK_SIZE were truncated.