### PR TITLE
Fix logging to stdout and respect reconnect_interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 6.0.1
-  - Fixed logging fail retry to stdout
+  - Fixed logging fail retry to stdout [#43](https://github.com/logstash-plugins/logstash-output-tcp/pull/43)
   - Fixed to use `reconnect_interval` when establish a connection
 
 ## 6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.1
+  - Fixed logging fail retry to stdout
+  - Fixed to use `reconnect_interval` when establish a connection
+
 ## 6.0.0
   - Removed obsolete field `message_format`
 

--- a/logstash-output-tcp.gemspec
+++ b/logstash-output-tcp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-tcp'
-  s.version         = '6.0.0'
+  s.version         = '6.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events over a TCP socket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This PR removed Stud::try to fix logging to stdout and respect `reconnect_interval` in connection retry

Fixed: #12
