### PR TITLE
Send entire payload considering `IO#syswrite` return size.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.1.1
+  - Fix: client ensures to transmit payload size data [#49](https://github.com/logstash-plugins/logstash-output-tcp/pull/49)
+
 ## 6.1.0
   - Feat: ssl_supported_protocols (TLSv1.3) [#47](https://github.com/logstash-plugins/logstash-output-tcp/pull/47)
   - Fix: close server and client sockets on plugin close

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 6.1.1
-  - Fix: client ensures to transmit payload size data [#49](https://github.com/logstash-plugins/logstash-output-tcp/pull/49)
+  - Fixes an issue where payloads larger than a connection's current TCP window could be silently truncated [#49](https://github.com/logstash-plugins/logstash-output-tcp/pull/49)
 
 ## 6.1.0
   - Feat: ssl_supported_protocols (TLSv1.3) [#47](https://github.com/logstash-plugins/logstash-output-tcp/pull/47)

--- a/lib/logstash/outputs/tcp.rb
+++ b/lib/logstash/outputs/tcp.rb
@@ -56,18 +56,22 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
 
   class Client
 
-    def initialize(socket, logger)
+    def initialize(socket, logger_context)
       @socket = socket
-      @logger = logger
+      @logger_context = logger_context
       @queue  = Queue.new
     end
 
     def run
       loop do
         begin
-          @socket.write(@queue.pop)
+          remaining_payload = @queue.pop
+          while remaining_payload && remaining_payload.bytesize > 0
+            written_bytes_size = @socket.write(remaining_payload)
+            remaining_payload = remaining_payload.byteslice(written_bytes_size..-1)
+          end
         rescue => e
-          log_warn 'socket write failed:', e, socket: (@socket ? @socket.to_s : nil)
+          @logger_context.log_warn 'socket write failed:', e, socket: (@socket ? @socket.to_s : nil)
           break
         end
       end
@@ -80,7 +84,7 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
     def close
       @socket.close
     rescue => e
-      log_warn 'socket close failed:', e, socket: (@socket ? @socket.to_s : nil)
+      @logger_context.log_warn 'socket close failed:', e, socket: (@socket ? @socket.to_s : nil)
     end
   end # class Client
 
@@ -135,6 +139,7 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
     require "socket"
     require "stud/try"
     @closed = Concurrent::AtomicBoolean.new(false)
+    @thread_no = Concurrent::AtomicFixnum.new(0)
     setup_ssl if @ssl_enable
 
     run_as_server if server?
@@ -165,11 +170,12 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
         end
         Thread.start(client_socket) do |client_socket|
           # monkeypatch a 'peer' method onto the socket.
-          client_socket.instance_eval { class << self; include ::LogStash::Util::SocketPeer end }
+          client_socket.extend(::LogStash::Util::SocketPeer)
           @logger.debug("accepted connection", client: client_socket.peer, server: "#{@host}:#{@port}")
-          client = Client.new(client_socket, @logger)
+          client = Client.new(client_socket, self)
           Thread.current[:client] = client
-          LogStash::Util.set_thread_name("[#{pipeline_id}]|output|tcp|client_socket-#{@client_threads.size}")
+          @thread_no.increment
+          LogStash::Util.set_thread_name("[#{pipeline_id}]|output|tcp|client_socket-#{@thread_no.value}")
           @client_threads << Thread.current
           client.run unless @closed.value
         end
@@ -189,22 +195,20 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
     @codec.on_event do |event, payload|
       begin
         client_socket = connect unless client_socket
-        r,w,_ = IO.select([client_socket],[client_socket])
 
-        # don't expect any reads, but a readable socket might
-        # mean the remote end closed, so read it and throw it away.
-        # we'll get an EOFError if it happens.
-        r.each { |readable| readable.sysread(16384) }
+        writable_oi = nil
+        while writable_oi.nil? || writable_oi.any? == false
+          readable_io, writable_oi, _ = IO.select([client_socket],[client_socket])
 
-        # first IO#select attempt allows to be sure read socket is available
-        # rest of IO#select calls allow to wait the socket to be writable ready
-        while w == nil || w.any? == false
-          r,w,_ = IO.select([client_socket],[client_socket])
+          # don't expect any reads, but a readable socket might
+          # mean the remote end closed, so read it and throw it away.
+          # we'll get an EOFError if it happens.
+          readable_io.each { |readable| readable.sysread(16384) }
         end
 
         while payload && payload.bytesize > 0
-          written = client_socket.syswrite(payload)
-          payload = payload.byteslice(written..-1)
+          written_bytes_size = client_socket.syswrite(payload)
+          payload = payload.byteslice(written_bytes_size..-1)
         end
       rescue => e
         log_warn "client socket failed:", e, host: @host, port: @port, socket: (client_socket ? client_socket.to_s : nil)
@@ -233,6 +237,18 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
     end
   end
 
+  def log_warn(msg, e, backtrace: @logger.debug?, **details)
+    details = details.merge message: e.message, exception: e.class
+    details[:backtrace] = e.backtrace if backtrace
+    @logger.warn(msg, details)
+  end
+
+  def log_error(msg, e, backtrace: @logger.info?, **details)
+    details = details.merge message: e.message, exception: e.class
+    details[:backtrace] = e.backtrace if backtrace
+    @logger.error(msg, details)
+  end
+
   private
 
   def connect
@@ -249,7 +265,7 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
           raise
         end
       end
-      client_socket.instance_eval { class << self; include ::LogStash::Util::SocketPeer end }
+      client_socket.extend(::LogStash::Util::SocketPeer)
       @logger.debug("opened connection", :client => client_socket.peer)
       return client_socket
     rescue => e
@@ -265,18 +281,6 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
 
   def pipeline_id
     execution_context.pipeline_id || 'main'
-  end
-
-  def log_warn(msg, e, backtrace: @logger.debug?, **details)
-    details = details.merge message: e.message, exception: e.class
-    details[:backtrace] = e.backtrace if backtrace
-    @logger.warn(msg, details)
-  end
-
-  def log_error(msg, e, backtrace: @logger.info?, **details)
-    details = details.merge message: e.message, exception: e.class
-    details[:backtrace] = e.backtrace if backtrace
-    @logger.error(msg, details)
   end
 
 end # class LogStash::Outputs::Tcp

--- a/logstash-output-tcp.gemspec
+++ b/logstash-output-tcp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-tcp'
-  s.version         = '6.1.0'
+  s.version         = '6.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events over a TCP socket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
### Issue description
As a client, when sending over 16K data with SSL enabled mode, it is confirmed that some portion of data is not transferred.
Eg. generated `16507` bytes data, `IO#syswrite` only sent `16367` bytes
```
payload = 'A' * (16 * 1024 + 123) # 16k + 123 = 16507
```

### What this PR does?
Takes in a count of `IO#syswrite` return size and iterates till payload is transmitted.

Closes #41 #30 #33 

### Testing
Added a logic to generate over 16K data and put some `printf`s to track the send size.
- Config
```
output {
    stdout {}
    tcp {
        host => "google.com"
        port => 443
        ssl_enable => true
    }
}
```

- Logs
```
Sending data: {"@timestamp":"2022-08-16T18:08:55.282249Z","event":{"original":"test"},"host":{"hostname":"localhost"},"@version":"1","message":"test"}
Sent size: 171

Sending data: {"@timestamp":"2022-08-16T18:09:04.404790Z","event":{"original":"generate"},"host":{"hostname":"localhost"},"@version":"1","message":"generate"}
Generating more than 16K payload...
Sent size: 16367
Sent size: 140 # expectation
```

- Checked the thread no on the messages
```
warning: thread "[main]|output|tcp|client_socket-1" terminated with exception (report_on_exception is true):
```

- Debugged logic
  - TCP server to test: [gist](https://gist.github.com/mashhurs/84cdbf774f54613339802bb561393c6e)
  - TCP client to test: [gist](https://gist.github.com/mashhurs/f9f80c68acd523632435cc03c5c6c972)