### PR TITLE
Backport TCP window, client closing fixes to 6.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.3
+  - Pulled applicable back-ports from 6.1.0
+    - Fix: Ensure sockets are closed when this plugin is closed
+
 ## 6.0.2
   - Fix: unable to start with password protected key [#45](https://github.com/logstash-plugins/logstash-output-tcp/pull/45)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 6.0.3
-  - Pulled applicable back-ports from 6.1.0
+  - Pulled applicable back-ports from 6.1.0 [#50](https://github.com/logstash-plugins/logstash-output-tcp/pull/50)
     - Fix: Ensure sockets are closed when this plugin is closed
-    - Fix: Fixes an issue where payloads larger than a connection's current TCP window could be silently truncated
+    - Fix: Fixes an issue in client mode where payloads larger than a connection's current TCP window could be silently truncated
+  - Fix: Fixes an issue in server mode where payloads larger than a connection's current TCP window could be silently truncated
 
 ## 6.0.2
   - Fix: unable to start with password protected key [#45](https://github.com/logstash-plugins/logstash-output-tcp/pull/45)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.0.3
   - Pulled applicable back-ports from 6.1.0
     - Fix: Ensure sockets are closed when this plugin is closed
+    - Fix: Fixes an issue where payloads larger than a connection's current TCP window could be silently truncated
 
 ## 6.0.2
   - Fix: unable to start with password protected key [#45](https://github.com/logstash-plugins/logstash-output-tcp/pull/45)

--- a/lib/logstash/outputs/tcp.rb
+++ b/lib/logstash/outputs/tcp.rb
@@ -72,7 +72,6 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
             written_bytes_size = @socket.write(payload)
             payload = payload.byteslice(written_bytes_size..-1)
             @logger_context.logger.log_trace(">transmitted #{written_bytes_size} bytes; #{payload.bytesize} bytes remain", socket: @peer_info) if @logger_context.logger.trace?
-            sleep 0.1 unless payload.empty?
           end
         rescue => e
           @logger_context.log_warn("tcp output exception: socket write failed", e, :socket => @peer_info)
@@ -195,7 +194,6 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
             written_bytes_size = @client_socket.syswrite(payload)
             payload = payload.byteslice(written_bytes_size..-1)
             @logger.trace(">transmitted #{written_bytes_size} bytes; #{payload.bytesize} bytes remain", socket: peer_info) if @logger.trace?
-            sleep 0.1 unless payload.empty?
           end
         rescue => e
           log_warn "client socket failed:", e, host: @host, port: @port, socket: peer_info

--- a/lib/logstash/outputs/tcp.rb
+++ b/lib/logstash/outputs/tcp.rb
@@ -186,6 +186,7 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
             written_bytes_size = client_socket.syswrite(payload)
             payload = payload.byteslice(written_bytes_size..-1)
             @logger.trace(">transmitted #{written_bytes_size} bytes; #{payload.bytesize} bytes remain", socket: peer_info) if @logger.trace?
+            sleep 0.1 unless payload.empty?
           end
         rescue => e
           log_warn "client socket failed:", e, host: @host, port: @port, socket: peer_info

--- a/logstash-output-tcp.gemspec
+++ b/logstash-output-tcp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-tcp'
-  s.version         = '6.0.2'
+  s.version         = '6.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events over a TCP socket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/tcp_spec.rb
+++ b/spec/outputs/tcp_spec.rb
@@ -3,7 +3,7 @@ require "logstash/outputs/tcp"
 require "flores/pki"
 
 describe LogStash::Outputs::Tcp do
-  subject { described_class.new(config) }
+  subject(:instance) { described_class.new(config) }
   let(:config) { {
     "host" => "localhost",
     "port" => 2000 + rand(3000),
@@ -70,6 +70,123 @@ describe LogStash::Outputs::Tcp do
           expect { subject.register }.to_not raise_error
         end
 
+      end
+    end
+  end
+
+  ##
+  # Reads `in_io` until EOF and writes the bytes
+  # it receives to `out_io`, tolerating partial writes.
+  def siphon_until_eof(in_io, out_io)
+    while (buffer = in_io.read(16*1024)) do
+      while (buffer && !buffer.empty?) do
+        bytes_written = out_io.write(buffer)
+        buffer = buffer.byteslice(bytes_written..-1)
+      end
+    end
+  end
+
+  context 'client mode' do
+    context 'transmitting data' do
+      let!(:io) { StringIO.new } # somewhere for our server to stash the data it receives
+
+      let(:server_host) { 'localhost' }
+      let(:server_port) { server.addr[1] } # get actual since we bind to port 0
+
+      let!(:server) { TCPServer.new(server_host, 0) }
+
+      let(:config) do
+        { 'host' => server_host, 'port' => server_port, 'mode' => 'client' }
+      end
+
+      let(:event) { LogStash::Event.new({"hello" => "world"})}
+
+      subject(:instance) { described_class.new(config) }
+
+      before(:each) do
+        # accepts ONE connection
+        @server_socket_thread = Thread.start do
+          client = server.accept
+          siphon_until_eof(client, io)
+        end
+        instance.register
+      end
+
+      after(:each) do
+        @server_socket_thread&.join
+      end
+
+      it 'encodes and transmits data' do
+        instance.receive(event)
+        instance.close # release the connection
+        sleep 1
+        expect(io.string).to include('"hello"','"world"')
+      end
+
+      context 'when payload is very large' do
+        let(:one_hundred_megabyte_message) { "a" * 1024 * 1024 * 100 }
+        let(:event) { LogStash::Event.new("message" => one_hundred_megabyte_message) }
+
+
+        it 'encodes and transmits data' do
+          instance.receive(event)
+          instance.close # release the connection
+          sleep 1
+          expect(io.string).to include('"message"',%Q("#{one_hundred_megabyte_message}"))
+        end
+      end
+    end
+  end
+
+  context 'server mode' do
+    context 'transmitting data' do
+      let(:server_host) { 'localhost' }
+      let(:server_port) { Random.rand(1024...5000) }
+
+      let(:config) do
+        { 'host' => server_host, 'port' => server_port, 'mode' => 'server' }
+      end
+
+      subject(:instance) { described_class.new(config) }
+
+      before(:each) { instance.register } # start listener
+      after(:each) { instance.close }
+
+      let(:event) { LogStash::Event.new({"hello" => "world"})}
+
+      context 'when one client is connected' do
+        let(:io) { StringIO.new }
+        let(:client_socket) { TCPSocket.new(server_host, server_port) }
+
+        before(:each) do
+          @client_socket_thread = Thread.start { siphon_until_eof(client_socket, io) }
+          sleep 1 # wait for it to actually connect
+        end
+
+        it 'encodes and transmits data' do
+          instance.receive(event)
+
+          sleep 1 # wait for the event to get sent...
+          instance.close # release the connection
+
+          @client_socket_thread.join(30) || fail('client failed to join')
+          expect(io.string).to include('"hello"','"world"')
+        end
+
+        context 'when payload is very large' do
+          let(:one_hundred_megabyte_message) { "a" * 1024 * 1024 * 100 }
+          let(:event) { LogStash::Event.new("message" => one_hundred_megabyte_message) }
+
+          it 'encodes and transmits data' do
+          instance.receive(event)
+
+          sleep 1 # wait for the event to get sent...
+          instance.close # release the connection
+
+          @client_socket_thread.join(30) || fail('client failed to join')
+            expect(io.string).to include('"message"',%Q("#{one_hundred_megabyte_message}"))
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Because 6.1.0 changed this plugin's dependency on Logstash to _require_ Logstash 8 and we still commercially support Logstash 7.13+, I have branched from 6.0.2 and am backporting relevant fixes to the 6.0.x series.

This is _not_ typical SEMVER, and I would like to find a way to _separately_ get 6.1.x of this plugin running on Logstash 7, even if it is without one or more of the features that were introduced for the 6.1 series of this plugin (e.g., works unless you try to use the new feature on LS7).

***

Here, we _manually_ backport two main fixes, each in its own commit for clarity:
 - client-closing and logging standardization (subset of #47 )
 - overlarge payload handling (#49)

We also:
 - cross-port the solution from #49 that handled overlarge payloads in client mode and applied them to server-mode.
 - add baseline specs

Unfortunately, in addition to breaking compatibility with LS 7.x, #47 also introduced two bugs that were fixed in #49 (repeating thread names, logger access), one more that is first-addressed here (crash while closing plugin), and will need to be forward-ported) so the lines are muddled.

I have elected to group whole fixes by commit as much as possible, instead of doing true backports.