### PR TITLE
Change client mode to write using the non-blocking operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.1.2
+  - Changed the client mode to write using the non-blocking method. [#50](https://github.com/logstash-plugins/logstash-output-tcp/pull/50)
+
 ## 6.1.1
   - Fixes an issue where payloads larger than a connection's current TCP window could be silently truncated [#49](https://github.com/logstash-plugins/logstash-output-tcp/pull/49)
 

--- a/logstash-output-tcp.gemspec
+++ b/logstash-output-tcp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-tcp'
-  s.version         = '6.1.1'
+  s.version         = '6.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events over a TCP socket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/tcp_spec.rb
+++ b/spec/outputs/tcp_spec.rb
@@ -269,14 +269,16 @@ describe LogStash::Outputs::Tcp do
         OpenSSL::SSL::SSLServer.new(server, ssl_context)
       end
 
-      before(:each) {
+      before(:each) do
         subject.register
-      }
+      end
 
-      after(:each) {
+      after(:each) do
         secure_server.close rescue nil
-      }
+      end
 
+      let(:message) { "a" }
+      let(:buffer) { "" }
 
       # This test confirms that this plugin is able to write to a TLS socket
       # multiple times.
@@ -287,9 +289,6 @@ describe LogStash::Outputs::Tcp do
       # causing a read to block forever.
       # This test will raise a Timeout exception with the old implementation.
       it 'successfully writes two messages' do
-        message = "a"
-
-        buffer = ""
         thread = Thread.start do
           expect {
             client = secure_server.accept


### PR DESCRIPTION
This PR changes the client mode to write using the `write_nonblock` method. The motivation for changing it is the current issues with `IO.select` and SSL, especially when using `TLSv1.3`.

According to the IO [docs](https://rubyapi.org/3.2/o/io#method-c-select), the readability notified by IO.select doesn’t necessarily mean readability from the `OpenSSL::SSL::SSLSocket` object, which might lead to a blocking operation, letting the plugin in a hang state when it tries to read from the socket. Removing the reading part of the existing code would also fix this issue, but `write_nonblock` is the official recommendation.

---
Closes https://github.com/elastic/logstash/issues/15052