### PR TITLE
Standardized SSL settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 6.2.0
+  - Reviewed and deprecated SSL settings to comply with Logstash's naming convention [#53](https://github.com/logstash-plugins/logstash-output-tcp/pull/53)
+    - Deprecated `ssl_enable` in favor of `ssl_enabled`
+    - Deprecated `ssl_cert` in favor of `ssl_certificate`
+    - Deprecated `ssl_verify` in favor of `ssl_client_authentication` when mode is `server`
+    - Deprecated `ssl_verify` in favor of `ssl_verification_mode` when mode is `client`
+  - Added `ssl_cipher_suites` configuration
+  - Added SSL configuration validations
+
 ## 6.1.2
   - Changed the client mode to write using the non-blocking method. [#52](https://github.com/logstash-plugins/logstash-output-tcp/pull/52)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -221,7 +221,7 @@ has a hostname or IP address that matches the names within the certificate.
 
 `none` performs no certificate validation.
 
-This setting can be used only if <<plugins-{type}s-{plugin}-mode>> is `client`.
+NOTE: This setting can be used only if <<plugins-{type}s-{plugin}-mode>> is `client`.
 
 [id="plugins-{type}s-{plugin}-ssl_verify"]
 ===== `ssl_verify` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -40,12 +40,18 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-mode>> |<<string,string>>, one of `["server", "client"]`|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|Yes
 | <<plugins-{type}s-{plugin}-reconnect_interval>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-ssl_cacert>> |a valid filesystem path|No
-| <<plugins-{type}s-{plugin}-ssl_cert>> |a valid filesystem path|No
-| <<plugins-{type}s-{plugin}-ssl_enable>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl_cacert>> |a valid filesystem path|__Deprecated__
+| <<plugins-{type}s-{plugin}-ssl_cert>> |a valid filesystem path|__Deprecated__
+| <<plugins-{type}s-{plugin}-ssl_certificate>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-ssl_cipher_suites>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-ssl_client_authentication>> |<<string,string>>, one of `["none", "optional", "required"]`|No
+| <<plugins-{type}s-{plugin}-ssl_enable>> |<<boolean,boolean>>|__Deprecated__
+| <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_key>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-ssl_key_passphrase>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_supported_protocols>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-ssl_verification_mode>> |<<string,string>>, one of `["full", "none"]`|No
 | <<plugins-{type}s-{plugin}-ssl_verify>> |<<boolean,boolean>>|No
 |=======================================================================
 
@@ -93,6 +99,7 @@ When connect failed,retry interval in sec.
 
 [id="plugins-{type}s-{plugin}-ssl_cacert"]
 ===== `ssl_cacert` 
+deprecated[6.2.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -101,14 +108,69 @@ The SSL CA certificate, chainfile or CA path. The system CA path is automaticall
 
 [id="plugins-{type}s-{plugin}-ssl_cert"]
 ===== `ssl_cert` 
+deprecated[6.2.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate>>]
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
 SSL certificate path
 
+[id="plugins-{type}s-{plugin}-ssl_certificate"]
+===== `ssl_certificate`
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+Path to certificate in PEM format. This certificate will be presented
+to the other part of the TLS connection.
+
+[id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_certificate_authorities`
+
+  * Value type is <<array,array>>
+  * Default value is `[]`
+
+Validate client certificate or certificate chain against these authorities.
+You can define multiple files. All the certificates will be read and added to the trust store.
+The system CA path is automatically included.
+
+[id="plugins-{type}s-{plugin}-ssl_cipher_suites"]
+===== `ssl_cipher_suites`
+
+  * Value type is a list of <<string,string>>
+  * There is no default value for this setting
+
+The list of cipher suites to use, listed by priorities.
+Supported cipher suites vary depending on the Java and protocol versions.
+
+[id="plugins-{type}s-{plugin}-ssl_client_authentication"]
+===== `ssl_client_authentication`
+
+  * Value can be any of: `none`, `optional`, `required`
+  * Default value is `none`
+
+Controls the server's behavior in regard to requesting a certificate from client connections:
+`none` disables the client authentication. `required` forces a client to present a certificate, while `optional` requests a client certificate
+but the client is not required to present one.
+
+When mutual TLS is enabled (`optional` or `required`), the certificate presented by the client must be signed by trusted
+<<plugins-{type}s-{plugin}-ssl_certificate_authorities>> (CAs).
+Please note that the server does not validate the client certificate CN (Common Name) or SAN (Subject Alternative Name).
+
+NOTE: This setting can be used only if <<plugins-{type}s-{plugin}-mode>> is `server` and <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> is set.
+
+
 [id="plugins-{type}s-{plugin}-ssl_enable"]
 ===== `ssl_enable` 
+deprecated[6.2.0, Replaced by <<plugins-{type}s-{plugin}-ssl_enabled>>]
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Enable SSL (must be set for other `ssl_` options to take effect).
+
+[id="plugins-{type}s-{plugin}-ssl_enabled"]
+===== `ssl_enabled`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -145,16 +207,31 @@ NOTE: If you configure the plugin to use `'TLSv1.1'` on any recent JVM, such as 
 the protocol is disabled by default and needs to be enabled manually by changing `jdk.tls.disabledAlgorithms` in
 the *$JDK_HOME/conf/security/java.security* configuration file. That is, `TLSv1.1` needs to be removed from the list.
 
+[id="plugins-{type}s-{plugin}-ssl_verification_mode"]
+===== `ssl_verification_mode`
+
+  * Value can be any of: `full`, `none`
+  * Default value is `full`
+
+Defines how to verify the certificates presented by another part in the TLS connection:
+
+`full` validates that the server certificate has an issue date that's within
+the not_before and not_after dates; chains to a trusted Certificate Authority (CA), and
+has a hostname or IP address that matches the names within the certificate.
+
+`none` performs no certificate validation.
+
+This setting can be used only if <<plugins-{type}s-{plugin}-mode>> is `client`.
+
 [id="plugins-{type}s-{plugin}-ssl_verify"]
 ===== `ssl_verify` 
+deprecated[6.2.0, Replaced by <<plugins-{type}s-{plugin}-ssl_client_authentication>> and <<plugins-{type}s-{plugin}-ssl_verification_mode>>]
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
 Verify the identity of the other end of the SSL connection against the CA.
 For input, sets the field `sslsubject` to that of the client certificate.
-
-
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/outputs/tcp.rb
+++ b/lib/logstash/outputs/tcp.rb
@@ -174,8 +174,13 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
   end
   private :new_ssl_context
 
+  def new_ssl_certificate_store
+    OpenSSL::X509::Store.new
+  end
+  private :new_ssl_certificate_store
+
   def load_cert_store
-    cert_store = OpenSSL::X509::Store.new
+    cert_store = new_ssl_certificate_store
     cert_store.set_default_paths
     @ssl_certificate_authorities&.each do |cert|
       cert_store.add_file(cert)

--- a/lib/logstash/outputs/tcp.rb
+++ b/lib/logstash/outputs/tcp.rb
@@ -3,6 +3,7 @@ require "logstash/outputs/base"
 require "logstash/namespace"
 require "thread"
 require "logstash/util/socket_peer"
+require "logstash/plugin_mixins/normalize_config_support"
 
 # Write events over a TCP socket.
 #
@@ -11,6 +12,8 @@ require "logstash/util/socket_peer"
 # Can either accept connections from clients or connect to a server,
 # depending on `mode`.
 class LogStash::Outputs::Tcp < LogStash::Outputs::Base
+
+  include LogStash::PluginMixins::NormalizeConfigSupport
 
   config_name "tcp"
   concurrency :single
@@ -33,17 +36,41 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
   config :mode, :validate => ["server", "client"], :default => "client"
 
   # Enable SSL (must be set for other `ssl_` options to take effect).
-  config :ssl_enable, :validate => :boolean, :default => false
+  config :ssl_enable, :validate => :boolean, :default => false, :deprecated => "Use 'ssl_enabled' instead."
+
+  # Enable SSL (must be set for other `ssl_` options to take effect).
+  config :ssl_enabled, :validate => :boolean, :default => false
+
+  # Controls the server’s behavior in regard to requesting a certificate from client connections.
+  # `none`: No client authentication
+  # `optional`: Requests a client certificate but the client is not required to present one.
+  # `required`: Forces a client to present a certificate.
+  # This option needs to be used with `ssl_certificate_authorities` and a defined list of CAs.
+  config :ssl_client_authentication, :validate => %w[none optional required], :default => 'none'
 
   # Verify the identity of the other end of the SSL connection against the CA.
   # For input, sets the field `sslsubject` to that of the client certificate.
-  config :ssl_verify, :validate => :boolean, :default => false
+  config :ssl_verify, :validate => :boolean, :default => false, :deprecated => "Use 'ssl_client_authentication' when `mode` is 'server' or 'ssl_verification_mode' when mode is `client`"
+
+  # Options to verify the server's certificate.
+  # "full": validates that the provided certificate has an issue date that’s within the not_before and not_after dates;
+  # chains to a trusted Certificate Authority (CA); has a hostname or IP address that matches the names within the certificate.
+  # "certificate": Validates the provided certificate and verifies that it’s signed by a trusted authority (CA), but does’t check the certificate hostname.
+  # "none": performs no certificate validation. Disabling this severely compromises security (https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf)
+  config :ssl_verification_mode, :validate => %w[full none], :default => 'full'
 
   # The SSL CA certificate, chainfile or CA path. The system CA path is automatically included.
-  config :ssl_cacert, :validate => :path
+  config :ssl_cacert, :validate => :path, :deprecated => "Use 'ssl_certificate_authorities' instead."
+
+  # Validate client certificate or certificate chain against these authorities. You can define multiple files.
+  # All the certificates will be read and added to the trust store.
+  config :ssl_certificate_authorities, :validate => :path, :list => true
 
   # SSL certificate path
-  config :ssl_cert, :validate => :path
+  config :ssl_cert, :validate => :path, :deprecated => "Use 'ssl_certificate' instead."
+
+  # SSL certificate path
+  config :ssl_certificate, :validate => :path
 
   # SSL key path
   config :ssl_key, :validate => :path
@@ -53,6 +80,9 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
 
   # NOTE: the default setting [] uses SSL engine defaults
   config :ssl_supported_protocols, :validate => ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'], :default => [], :list => true
+
+  # The list of ciphers suite to use
+  config :ssl_cipher_suites, :validate => :string, :list => true
 
   class Client
 
@@ -95,8 +125,8 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
     require "openssl"
 
     @ssl_context = new_ssl_context
-    if @ssl_cert
-      @ssl_context.cert = OpenSSL::X509::Certificate.new(File.read(@ssl_cert))
+    if @ssl_certificate
+      @ssl_context.cert = OpenSSL::X509::Certificate.new(File.read(@ssl_certificate))
       if @ssl_key
         # if we have an encrypted key and a password is not provided (nil) than OpenSSL::PKey::RSA
         # prompts the user to enter a password interactively - we do not want to do that,
@@ -104,17 +134,21 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
         @ssl_context.key = OpenSSL::PKey::RSA.new(File.read(@ssl_key), @ssl_key_passphrase.value || '')
       end
     end
-    if @ssl_verify
-      @cert_store = OpenSSL::X509::Store.new
-      # Load the system default certificate path to the store
-      @cert_store.set_default_paths
-      if File.directory?(@ssl_cacert)
-        @cert_store.add_path(@ssl_cacert)
+
+    @ssl_context.cert_store = load_cert_store
+    if server?
+      if @ssl_client_authentication == 'none'
+        @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
       else
-        @cert_store.add_file(@ssl_cacert)
+        @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        @ssl_context.verify_mode |= OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT if @ssl_client_authentication == 'required'
       end
-      @ssl_context.cert_store = @cert_store
-      @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER|OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
+    else
+      if @ssl_verification_mode == 'none'
+        @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      else
+        @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER|OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
+      end
     end
 
     @ssl_context.min_version = :TLS1_1 # not strictly required - JVM should have disabled TLSv1
@@ -127,6 +161,9 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
       disabled_protocols.map! { |v| OpenSSL::SSL.const_get "OP_NO_#{v.sub('.', '_')}" }
       @ssl_context.options = disabled_protocols.reduce(@ssl_context.options, :|)
     end
+
+    @ssl_context.ciphers = @ssl_cipher_suites if @ssl_cipher_suites&.any?
+
     @ssl_context
   end
   private :setup_ssl
@@ -137,13 +174,31 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
   end
   private :new_ssl_context
 
+  def load_cert_store
+    cert_store = OpenSSL::X509::Store.new
+    cert_store.set_default_paths
+    @ssl_certificate_authorities&.each do |cert|
+      cert_store.add_file(cert)
+    end
+    cert_store
+  end
+  private :load_cert_store
+
+  def initialize(*args)
+    super(*args)
+    setup_ssl_params!
+  end
+
   # @overload Base#register
   def register
     require "socket"
     require "stud/try"
+
+    validate_ssl_config!
+
     @closed = Concurrent::AtomicBoolean.new(false)
     @thread_no = Concurrent::AtomicFixnum.new(0)
-    setup_ssl if @ssl_enable
+    setup_ssl if @ssl_enabled
 
     if server?
       run_as_server
@@ -160,20 +215,35 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
       @logger.error("Could not start tcp server: Address in use", host: @host, port: @port)
       raise
     end
-    if @ssl_enable
+    if @ssl_enabled
       @server_socket = OpenSSL::SSL::SSLServer.new(@server_socket, @ssl_context)
-    end # @ssl_enable
+    end # @ssl_enabled
     @client_threads = Concurrent::Array.new
 
     @accept_thread = Thread.new(@server_socket) do |server_socket|
       LogStash::Util.set_thread_name("[#{pipeline_id}]|output|tcp|server_accept")
       loop do
         break if @closed.value
-        client_socket = server_socket.accept_nonblock exception: false
-        if client_socket == :wait_readable
-          IO.select [ server_socket ]
-          next
+        # OpenSSL::SSL::SSLServer does not support the #accept_nonblock method.
+        # When SSL is enabled, it needs to use the blocking counterpart and ignore
+        # SSLError errors, as they may be client's issues such as missing client's
+        # certificates, ciphers, etc. If it's not rescued here, it would close the
+        # TCP server and exit the plugin.
+        if @ssl_enabled
+          begin
+            client_socket = server_socket.accept
+          rescue OpenSSL::SSL::SSLError => e
+            log_warn("SSL Error", e)
+            retry unless @closed.value
+          end
+        else
+          client_socket = server_socket.accept_nonblock exception: false
+          if client_socket == :wait_readable
+            IO.select [ server_socket ]
+            next
+          end
         end
+
         Thread.start(client_socket) do |client_socket|
           # monkeypatch a 'peer' method onto the socket.
           client_socket.extend(::LogStash::Util::SocketPeer)
@@ -256,7 +326,7 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
   def connect
     begin
       client_socket = TCPSocket.new(@host, @port)
-      if @ssl_enable
+      if @ssl_enabled
         client_socket = OpenSSL::SSL::SSLSocket.new(client_socket, @ssl_context)
         begin
           client_socket.connect
@@ -276,6 +346,95 @@ class LogStash::Outputs::Tcp < LogStash::Outputs::Base
       retry
     end
   end # def connect
+
+  def validate_ssl_config!
+    unless @ssl_enabled
+      ignored_ssl_settings = original_params.select { |k| k != 'ssl_enabled' && k != 'ssl_enable' && k.start_with?('ssl_') }
+      @logger.warn("Configured SSL settings are not used when `#{provided_ssl_enabled_config_name}` is set to `false`: #{ignored_ssl_settings.keys}") if ignored_ssl_settings.any?
+      return
+    end
+
+    if @ssl_certificate && !@ssl_key
+      raise LogStash::ConfigurationError, "Using an `ssl_certificate` requires an `ssl_key`"
+    elsif @ssl_key && !@ssl_certificate
+      raise LogStash::ConfigurationError, 'An `ssl_certificate` is required when using an `ssl_key`'
+    end
+
+    if server?
+      validate_server_ssl_config!
+    else
+      validate_client_ssl_config!
+    end
+  end
+
+  def validate_client_ssl_config!
+    if original_params.include?('ssl_client_authentication')
+      raise LogStash::ConfigurationError, "`ssl_client_authentication` must not be configured when mode is `client`, use `ssl_verification_mode` instead."
+    end
+  end
+
+  def validate_server_ssl_config!
+    if original_params.include?('ssl_verification_mode')
+      raise LogStash::ConfigurationError, "`ssl_verification_mode` must not be configured when mode is `server`, use `ssl_client_authentication` instead."
+    end
+
+    if @ssl_certificate.nil?
+      raise LogStash::ConfigurationError, "An `ssl_certificate` is required when `#{provided_ssl_enabled_config_name}` => true"
+    end
+
+    if requires_ssl_certificate_authorities? && (@ssl_certificate_authorities.nil? || @ssl_certificate_authorities.empty?)
+      raise LogStash::ConfigurationError, "An `ssl_certificate_authorities` is required when `ssl_client_authentication` => `#{@ssl_client_authentication}`"
+    end
+  end
+
+  def requires_ssl_certificate_authorities?
+    original_params.include?('ssl_client_authentication') && @ssl_client_authentication != 'none'
+  end
+
+  def provided_ssl_enabled_config_name
+    original_params.include?('ssl_enable') ? 'ssl_enable' : 'ssl_enabled'
+  end
+
+  def setup_ssl_params!
+    @ssl_enabled = normalize_config(:ssl_enabled) do |normalizer|
+      normalizer.with_deprecated_alias(:ssl_enable)
+    end
+
+    @ssl_certificate = normalize_config(:ssl_certificate) do |normalizer|
+      normalizer.with_deprecated_alias(:ssl_cert)
+    end
+
+    if server?
+      @ssl_client_authentication = normalize_config(:ssl_client_authentication) do |normalizer|
+        normalizer.with_deprecated_mapping(:ssl_verify) do |ssl_verify|
+          ssl_verify == true ? 'required' : 'none'
+        end
+      end
+    else
+      @ssl_verification_mode = normalize_config(:ssl_verification_mode) do |normalize|
+        normalize.with_deprecated_mapping(:ssl_verify) do |ssl_verify|
+          ssl_verify == true ? 'full' : 'none'
+        end
+      end
+
+      # Keep backwards compatibility with the default :ssl_verify value (false)
+      if !original_params.include?('ssl_verify') && !original_params.include?('ssl_verification_mode')
+        @ssl_verification_mode = 'none'
+      end
+    end
+
+    @ssl_certificate_authorities = normalize_config(:ssl_certificate_authorities) do |normalize|
+      normalize.with_deprecated_mapping(:ssl_cacert) do |ssl_cacert|
+        if File.directory?(ssl_cacert)
+          Dir.children(ssl_cacert)
+          .map{ |f| File.join(ssl_cacert, f) }
+          .reject{ |f| File.directory?(f) || File.basename(f).start_with?('.') }
+        else
+          [ssl_cacert]
+        end
+      end
+    end
+  end
 
   def server?
     @mode == "server"

--- a/logstash-output-tcp.gemspec
+++ b/logstash-output-tcp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-tcp'
-  s.version         = '6.1.2'
+  s.version         = '6.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events over a TCP socket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-core', '>= 8.1.0'
   s.add_runtime_dependency 'logstash-codec-json'
   s.add_runtime_dependency 'stud'
+  s.add_runtime_dependency 'logstash-mixin-normalize_config_support', '~>1.0'
 
   s.add_runtime_dependency 'jruby-openssl', '>= 0.12.2' # 0.12 supports TLSv1.3
 

--- a/spec/outputs/tcp_spec.rb
+++ b/spec/outputs/tcp_spec.rb
@@ -108,6 +108,20 @@ describe LogStash::Outputs::Tcp do
     end
   end
 
+  context "with cipher suites" do
+    let(:config) do
+      super().merge('ssl_cipher_suites' => %w[TLS_RSA_WITH_AES_128_GCM_SHA256 TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA])
+    end
+
+    it "limits the ciphers selection" do
+      ssl_context = OpenSSL::SSL::SSLContext.new
+      allow(subject).to receive(:new_ssl_context).and_return(ssl_context)
+      subject.send :setup_ssl
+      expect(ssl_context.ciphers.length).to eq(2)
+      expect(ssl_context.ciphers).to satisfy { |arr| arr[0].include?('AES128-GCM-SHA256') && arr[1].include?('EDH-RSA-DES-CBC3-SHA') }
+    end
+  end
+
   context "client mode" do
     before { subject.register }
 
@@ -136,7 +150,7 @@ describe LogStash::Outputs::Tcp do
   end
 
   context "when enabling SSL" do
-    let(:config) { super().merge("ssl_enable" => true, 'codec' => 'plain') }
+    let(:config) { super().merge("ssl_enabled" => true, 'codec' => 'plain') }
     context "and not providing a certificate/key pair" do
       it "registers without error" do
         expect { subject.register }.to_not raise_error
@@ -145,13 +159,18 @@ describe LogStash::Outputs::Tcp do
 
     context "and providing a certificate/key pair" do
       let(:cert_key_pair) { Flores::PKI.generate }
-      let(:certificate) { cert_key_pair.first }
-      let(:cert_file) do
-        path = Tempfile.new('foo').path
-        IO.write(path, certificate.to_s)
+      let(:certificate) do
+        path = Tempfile.new('certificate').path
+        IO.write(path, cert_key_pair.first.to_s)
         path
       end
-      let(:config) { super().merge("ssl_cert" => cert_file) }
+      let(:key) do
+        path = Tempfile.new('key').path
+        IO.write(path, cert_key_pair[1].to_s)
+        path
+      end
+      let(:config) { super().merge("ssl_certificate" => certificate, "ssl_key" => key) }
+
       it "registers without error" do
         expect { subject.register }.to_not raise_error
       end
@@ -162,7 +181,7 @@ describe LogStash::Outputs::Tcp do
     context "ES generated plain-text certificate/key" do
       let(:key_file) { File.join(FIXTURES_PATH, 'plaintext/instance.key') }
       let(:crt_file) { File.join(FIXTURES_PATH, 'plaintext/instance.crt') }
-      let(:config) { super().merge("ssl_cert" => crt_file, "ssl_key" => key_file) }
+      let(:config) { super().merge("ssl_certificate" => crt_file, "ssl_key" => key_file) }
 
       it "registers without error" do
         expect { subject.register }.to_not raise_error
@@ -238,7 +257,7 @@ describe LogStash::Outputs::Tcp do
     context "encrypted key using PKCS#1" do
       let(:key_file) { File.join(FIXTURES_PATH, 'encrypted/instance.key') }
       let(:crt_file) { File.join(FIXTURES_PATH, 'encrypted/instance.crt') }
-      let(:config) { super().merge("ssl_cert" => crt_file, "ssl_key" => key_file) }
+      let(:config) { super().merge("ssl_certificate" => crt_file, "ssl_key" => key_file) }
 
       it "registers with error (due missing password)" do
         expect { subject.register }.to raise_error(OpenSSL::PKey::RSAError) # TODO need a better error
@@ -258,7 +277,7 @@ describe LogStash::Outputs::Tcp do
     context "and protocol is TLSv1.3" do
       let(:key_file) { File.join(FIXTURES_PATH, 'plaintext/instance.key') }
       let(:crt_file) { File.join(FIXTURES_PATH, 'plaintext/instance.crt') }
-      let(:config) { super().merge("ssl_cert" => crt_file, "ssl_key" => key_file) }
+      let(:config) { super().merge("ssl_certificate" => crt_file, "ssl_key" => key_file) }
 
       let(:secure_server) do
         ssl_context = OpenSSL::SSL::SSLContext.new
@@ -305,6 +324,145 @@ describe LogStash::Outputs::Tcp do
         thread.join(2)
 
         expect(buffer).to eq(message * 2)
+      end
+    end
+
+    context "with only ssl_certificate set" do
+      let(:config) { super().merge("ssl_certificate" => File.join(FIXTURES_PATH, 'plaintext/instance.crt')) }
+
+      it "should raise a configuration error to request also `ssl_key`" do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /Using an `ssl_certificate` requires an `ssl_key`/)
+      end
+    end
+
+    context "with only ssl_key set" do
+      let(:config) { super().merge("ssl_key" => File.join(FIXTURES_PATH, 'plaintext/instance.key')) }
+
+      it "should raise a configuration error to request also `ssl_key`" do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /An `ssl_certificate` is required when using an `ssl_key`/)
+      end
+    end
+
+    context "and mode is server" do
+      let(:config) do
+        {
+          "host" => "127.0.0.1",
+          "port" => port,
+          "mode" => 'server',
+          "ssl_enabled" => true,
+          "ssl_certificate" => File.join(FIXTURES_PATH, 'plaintext/instance.crt'),
+          "ssl_key" => File.join(FIXTURES_PATH, 'plaintext/instance.key'),
+        }
+      end
+
+      context "with no ssl_certificate" do
+        let(:config) { super().reject { |k| "ssl_key".eql?(k) || "ssl_certificate".eql?(k) } }
+
+        it "should raise a configuration error" do
+          expect { subject.register }.to raise_error(LogStash::ConfigurationError, /An `ssl_certificate` is required when `ssl_enabled` => true/)
+        end
+      end
+
+      context "with ssl_client_authentication = `none` and no ssl_certificate_authorities" do
+        let(:config) { super().merge(
+          'ssl_client_authentication' => 'none',
+          'ssl_certificate_authorities' => []
+        ) }
+
+        it "should register without errors" do
+          expect { subject.register }.to_not raise_error
+        end
+      end
+
+      context "with deprecated ssl_verify = true and no ssl_certificate_authorities" do
+        let(:config) { super().merge(
+          'ssl_verify' => true,
+          'ssl_certificate_authorities' => []
+        ) }
+
+        it "should register without errors" do
+          expect { subject.register }.to_not raise_error
+        end
+      end
+
+      %w[required optional].each do |ssl_client_authentication|
+        context "with ssl_client_authentication = `#{ssl_client_authentication}` and no ssl_certificate_authorities" do
+          let(:config) { super().merge(
+            'ssl_client_authentication' => ssl_client_authentication,
+            'ssl_certificate_authorities' => []
+          ) }
+
+          it "should raise a configuration error" do
+            expect { subject.register }.to raise_error(LogStash::ConfigurationError, /An `ssl_certificate_authorities` is required when `ssl_client_authentication` => `#{ssl_client_authentication}`/)
+          end
+        end
+      end
+
+      context "with ssl_verification_mode" do
+        let(:config) do
+          super().merge 'ssl_verification_mode' => 'full'
+        end
+
+        it "should raise a configuration error" do
+          expect{subject.register}.to raise_error(LogStash::ConfigurationError, /`ssl_verification_mode` must not be configured when mode is `server`, use `ssl_client_authentication` instead/)
+        end
+      end
+    end
+
+    context "with deprecated settings" do
+      let(:ssl_verify) { true }
+      let(:certificate_path) { File.join(FIXTURES_PATH, 'plaintext/instance.crt') }
+      let(:config) do
+        {
+          "host" => "127.0.0.1",
+          "port" => port,
+          "ssl_enable" => true,
+          "ssl_cert" => certificate_path,
+          "ssl_key" => File.join(FIXTURES_PATH, 'plaintext/instance.key'),
+          "ssl_verify" => ssl_verify
+        }
+      end
+
+      context "and mode is server" do
+        let(:config) { super().merge("mode" => 'server') }
+        [true, false].each do |verify|
+          context "and ssl_verify is #{verify}" do
+            let(:ssl_verify) { verify }
+
+            it "should set new configs variables" do
+              subject.register
+              expect(subject.instance_variable_get(:@ssl_enabled)).to eql(true)
+              expect(subject.instance_variable_get(:@ssl_client_authentication)).to eql(verify ? 'required' : 'none')
+              expect(subject.instance_variable_get(:@ssl_certificate)).to eql(certificate_path)
+            end
+          end
+        end
+      end
+
+      context "and mode is client" do
+        let(:config) { super().merge("mode" => 'client') }
+        [true, false].each do |verify|
+          context "and ssl_verify is #{verify}" do
+            let(:ssl_verify) { verify }
+
+            it "should set new configs variables" do
+              subject.register
+              expect(subject.instance_variable_get(:@ssl_enabled)).to eql(true)
+              expect(subject.instance_variable_get(:@ssl_verification_mode)).to eql(verify ? 'full' : 'none')
+              expect(subject.instance_variable_get(:@ssl_certificate)).to eql(certificate_path)
+            end
+          end
+        end
+      end
+    end
+
+    context "with ssl_client_authentication" do
+      let(:config) do
+        super().merge 'ssl_client_authentication' => 'required'
+      end
+
+      it "should raise a configuration error" do
+        expect{subject.register}.to raise_error(LogStash::ConfigurationError, /`ssl_client_authentication` must not be configured when mode is `client`, use `ssl_verification_mode` instead/)
       end
     end
   end


### PR DESCRIPTION
- Deprecated `ssl_enable` in favor of `ssl_enabled`
- Deprecated `ssl_cert` in favor of `ssl_certificate`
- Deprecated `ssl_verify` in favor of `ssl_client_authentication` when mode is `server`
- Deprecated `ssl_verify` in favor of `ssl_verification_mode` when mode is `client`
- Added `ssl_cipher_suites` configuration and common validations
- Fixed the `server` mode when SSL is enabled

---
Closes https://github.com/elastic/logstash/issues/14926