### PR TITLE
Update CHANGELOG.md to fix link to PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## 7.0.0
   - SSL settings that were marked deprecated in version `6.2.0` are now marked obsolete, and will prevent the plugin from starting.
+  [#58](https://github.com/logstash-plugins/logstash-output-tcp/pull/58)
   - These settings are:
       - `ssl_cert`, which should be replaced by `ssl_certificate`
       - `ssl_cacert`, which should be replaced by `ssl_certificate_authorities`
       - `ssl_enable`, which should be replaced by `ssl_enabled`
       - `ssl_verify`, which should be replaced by `ssl_client_authentication` when `mode` is `server` or `ssl_verification_mode`when mode is `client`
-      - [58](https://github.com/logstash-plugins/logstash-output-tcp/pull/58)
+
 ## 6.2.1
   - Document correct default plugin codec [#54](https://github.com/logstash-plugins/logstash-output-tcp/pull/54)
 


### PR DESCRIPTION
Improper link formats can't be transformed properly when we generate release notes

<img width="836" alt="Screenshot 2025-02-14 at 9 50 15 AM" src="https://github.com/user-attachments/assets/41460c81-79fb-4a41-9652-16d0a66237d2" />

