### PR TITLE
Removed Logstash7 eol (branch 6.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 import:
   - logstash-plugins/.ci:travis/travis.yml@1.x
-
-jobs:
-  exclude:
-  - env: ELASTIC_STACK_VERSION=7.current
-  - env: SNAPSHOT=true ELASTIC_STACK_VERSION=7.current
+  


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
